### PR TITLE
amcl map topic modify

### DIFF
--- a/pathplanning/launch/amcl.launch
+++ b/pathplanning/launch/amcl.launch
@@ -7,6 +7,8 @@
 
   <!-- AMCL -->
   <node pkg="amcl" type="amcl" name="amcl">
+
+    <param name="use_map_topic"             value="true"/>
     <param name="min_particles"             value="100"/>
     <param name="max_particles"             value="5000"/>
     <param name="kld_err"                   value="0.02"/>


### PR DESCRIPTION
## use_map_topic = true 로 해줘야 amcl 노드에 "/map" topic이 들어가는 걸로 알고 있어서 param 값 수정했습니다.
- 시뮬레이터 상에선 /map이 들어갔을 때 성능이 더 좋아졌습니다.